### PR TITLE
Typo in cmodel.cpp:CM_CombineTrace

### DIFF
--- a/qcommon/cmodel.cpp
+++ b/qcommon/cmodel.cpp
@@ -2208,7 +2208,7 @@ bool CM_CombineTrace(trace_t &trace1, const trace_t &trace2)
 		ret = true;
 	}
 
-	if (trace1.startsolid)
+	if (trace2.startsolid)
 	{
 		trace1.startsolid = true;
 		ret = true;


### PR DESCRIPTION
Здравствуйте!
Прежде всего я хочу искренне поблагодарить за колоссальную проделанную работу! Особенно за все что касается генерации брашей для карт q1 & hl и их трейс лайн.

Ошибка в коде cmodel.cpp на линии 2211, там вместо 'if (trace1.startsolid)' должно быть 'if (trace2.startsolid)'.